### PR TITLE
[Tests] Fix e2e Patient create failure by using unique test payload

### DIFF
--- a/tests/e2e/test_tools.py
+++ b/tests/e2e/test_tools.py
@@ -19,6 +19,7 @@ import json
 import logging
 import pytest_asyncio
 import asyncio
+import uuid
 
 from typing import Dict
 import mcp.types as types
@@ -65,12 +66,16 @@ async def test_tool_get_capabilities(mcp_server) -> None:
 
 @pytest_asyncio.fixture
 async def patient_id(mcp_server) -> str | None:
+    suffix = uuid.uuid4().hex[:8]
     request_payload = {
         "type": "Patient",
         "payload": {
             "resourceType": "Patient",
             "gender": "male",
-            "name": {"family": "TestFamily", "given": ["TestGiven"]},
+            "name": {
+                "family": f"TestFamily-{suffix}",
+                "given": [f"TestGiven-{suffix}"],
+            },
         },
     }
     logger.debug("[TOOL REQUEST] create:", request_payload)


### PR DESCRIPTION
## Purpose
This PR fixes a flaky e2e failure caused by creating a Patient with a static payload against the public HAPI FHIR server.

## What changed
- Added a UUID-based suffix for test data generation in the e2e Patient fixture.
- Updated family and given name fields to be unique for each test run.

## Why
The shared upstream server may reject repeated creates as duplicates, which caused intermittent failures in read/search/update/delete tests that depend on fixture creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test data isolation by generating unique patient identifiers for each test run instead of using hardcoded values, reducing potential data conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->